### PR TITLE
Multithreading bug with accessing this.searchProviders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
       <groupId>com.celements</groupId>
       <artifactId>celements</artifactId>
-      <version>2.6</version>
+      <version>2.7</version>
   </parent>
   <artifactId>xwiki-platform-search-lucene</artifactId>
   <name>XWiki Platform - Search - Lucene</name>
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-core</artifactId>
-      <version>1.63</version>
+      <version>1.91</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
@@ -247,7 +247,7 @@ public class IndexUpdater extends AbstractXWikiRunnable implements EventListener
                 }
             }
 
-            this.plugin.openSearchers();
+            this.plugin.openSearchers(context);
         }
     }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
@@ -247,7 +247,7 @@ public class IndexUpdater extends AbstractXWikiRunnable implements EventListener
                 }
             }
 
-            this.plugin.openSearchers(context);
+            this.plugin.openSearchers();
         }
     }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
@@ -64,13 +64,15 @@ public class SearcherProvider {
   }
 
   public void connect() {
-    if (this.markToClose) {
-      throw new IllegalStateException("you may not connect to a SearchProvider"
-          + " marked to close.");
+    if (!connectedThreads.contains(Thread.currentThread())) {
+      if (this.markToClose) {
+        throw new IllegalStateException("you may not connect to a SearchProvider"
+            + " marked to close.");
+      }
+      LOGGER.debug("connect searcherProvider [" + System.identityHashCode(this) + "] to ["
+          + Thread.currentThread() + "].");
+      connectedThreads.add(Thread.currentThread());
     }
-    LOGGER.debug("connect searcherProvider [" + System.identityHashCode(this) + "] to ["
-        + Thread.currentThread() + "].");
-    connectedThreads.add(Thread.currentThread());
   }
 
   public boolean isClosed() {

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
@@ -63,8 +63,11 @@ public class SearcherProvider {
     return connectedThreads;
   }
 
+  /**
+   * connect and markToClose need to be externally synchronized
+   */
   public void connect() {
-    if (!connectedThreads.contains(Thread.currentThread())) {
+    if (!checkConnected()) {
       if (this.markToClose) {
         throw new IllegalStateException("you may not connect to a SearchProvider"
             + " marked to close.");
@@ -104,6 +107,9 @@ public class SearcherProvider {
     return this.markToClose;
   }
 
+  /**
+   * connect and markToClose need to be externally synchronized
+   */
   public void markToClose() throws IOException {
     if (!this.markToClose) {
       LOGGER.debug("markToClose searcherProvider [" + System.identityHashCode(this)

--- a/src/test/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProviderTest.java
+++ b/src/test/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProviderTest.java
@@ -46,6 +46,21 @@ public class SearcherProviderTest extends AbstractBridgedComponentTestCase {
   }
 
   @Test
+  public void testConnect_connectAconnectedThreadAfterMarkToClose() throws Exception {
+    assertTrue(searcherProvider.internal_getConnectedThreads().isEmpty());
+    searcherProvider.connect();
+    searcherProvider.markToClose();
+    replayDefault();
+    try {
+      searcherProvider.connect();
+    } catch(IllegalStateException exp) {
+      fail("connect may not throw an IllegalStateException on if the thread is already"
+          + " connected");
+    }
+    verifyDefault();
+  }
+
+  @Test
   public void testConnect() {
     replayDefault();
     assertTrue(searcherProvider.internal_getConnectedThreads().isEmpty());


### PR DESCRIPTION
synchronise access to plugin instance variable searchProviders to solve a multithreading issue.

Please review and merge if ok.
