### PR TITLE
Old code in SearchResults

### DIFF
--- a/src/main/java/com/xpn/xwiki/plugin/lucene/SearchResults.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/SearchResults.java
@@ -212,55 +212,14 @@ public class SearchResults extends Api {
    *         and containing up to <code>items</code> elements.
    */
   public List<SearchResult> getResults(int beginIndex, int items) {
-    final int listStartIndex = beginIndex - 1;
-    final int listEndIndex = listStartIndex + items;
-    int resultcount = 0;
-    List<SearchResult> relResults = this.relevantResults;
-    if (relResults == null) {
-      relResults = new ArrayList<SearchResult>();
-      TopDocs docs = this.results.topDocs();
-      String database = this.context.getDatabase();
-      try {
-        for (int i = 0; i < docs.scoreDocs.length; i++) {
-          SearchResult result = null;
-          try {
-            result = new SearchResult(this.searcher.doc(docs.scoreDocs[i].doc),
-                docs.scoreDocs[i].score, this.xwiki);
-
-            this.context.setDatabase(result.getWiki());
-
-            String pageName = null;
-            if (result.isWikiContent()) {
-              pageName = result.getWiki() + ":" + result.getSpace() + "."
-                  + result.getName();
-            }
-            if (result.isWikiContent() && this.xwiki.exists(pageName)
-                && this.xwiki.checkAccess(pageName, "view")) {
-              if (resultcount >= listStartIndex) {
-                relResults.add(result);
-              }
-              resultcount++;
-              if (resultcount == listEndIndex) {
-                return relResults;
-              }
-            }
-          } catch (Exception e) {
-            LOGGER.error("error getting search result", e);
-          }
-        }
-      } finally {
-        this.context.setDatabase(database);
-      }
-
-      return relResults;
+    int listStartIndex = beginIndex - 1;
+    int listEndIndex = listStartIndex + items;
+    int resultcount = getRelevantResults().size();
+    listEndIndex = listEndIndex < resultcount ? listEndIndex : resultcount;
+    if (listStartIndex <= listEndIndex) {
+      return getRelevantResults().subList(listStartIndex, listEndIndex);
     } else {
-      resultcount = getRelevantResults().size();
-      int theListEndIndex = listEndIndex < resultcount ? listEndIndex : resultcount;
-      if (listStartIndex <= theListEndIndex) {
-        return getRelevantResults().subList(listStartIndex, theListEndIndex);
-      } else {
-        return Collections.emptyList();
-      }
+      return Collections.emptyList();
     }
   }
 


### PR DESCRIPTION
Stumbled across old code in SearchResults.getResults(int, int) which seemed to be mostly duplicate of SearchResults.getRelevantResults(). However, it did not take into account the "skipChecks" boolean (since it's a newer addition to SearchResults) and could have therefore caused some problems.
I guess this code part was intended to be refactored into "getRelevantResults" at some point, but its' deletion was forgotten.

Please confirm & check code.
