### PR TITLE
IndexUpdater Exception catch and exit conditions

### DIFF
--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
@@ -142,6 +142,7 @@ public class IndexUpdater extends AbstractXWikiRunnable implements EventListener
    * processing the queue and then shut down gracefully
    */
   public void doExit() {
+    LOGGER.info("doExit called");
     exit.set(true);
   }
 
@@ -279,8 +280,8 @@ public class IndexUpdater extends AbstractXWikiRunnable implements EventListener
    */
   private void checkForInterrupt() {
     if (Thread.currentThread().isInterrupted()) {
-      doExit();
       LOGGER.error("IndexUpdater was interrupted, shutting down");
+      doExit();
     }
   }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
@@ -250,13 +250,13 @@ public class IndexUpdater extends AbstractXWikiRunnable implements EventListener
       try {
         indexData(data);
         hasUncommitedWrites = true;
-        if ((System.currentTimeMillis() - lastCommitTime) >= commitInterval) {
-          commitIndex();
-          lastCommitTime = System.currentTimeMillis();
-          hasUncommitedWrites = false;
-        }
-      } catch (IOException | XWikiException exc) {
+      } catch (Exception exc) {
         LOGGER.error("error indexing document '{}'", data, exc);
+      }
+      if ((System.currentTimeMillis() - lastCommitTime) >= commitInterval) {
+        commitIndex();
+        lastCommitTime = System.currentTimeMillis();
+        hasUncommitedWrites = false;
       }
     }
     if (hasUncommitedWrites) {


### PR DESCRIPTION
- catching Exception in IndexUpdater main loop
- checking for interrupt flag
- not accepting new queue entries when exit is set 
