### PR TITLE
Index Rebuild disable observation events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <parent>
       <groupId>com.celements</groupId>
       <artifactId>celements</artifactId>
-      <version>2.17</version>
+      <version>3.0</version>
   </parent>
   <artifactId>xwiki-platform-search-lucene</artifactId>
   <name>XWiki Platform - Search - Lucene</name>
-  <version>2.30-SNAPSHOT</version>
+  <version>3.0-SNAPSHOT</version>
   <description>XWiki Platform - Search - Lucene</description>
   <scm>
     <connection>scm:git:git://github.com/celements/xwiki-platform-search-lucene.git</connection>
@@ -49,8 +49,14 @@
     </dependency>
     <dependency>
       <groupId>com.celements</groupId>
+      <artifactId>celements-model</artifactId>
+      <version>3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.celements</groupId>
       <artifactId>celements-core</artifactId>
-      <version>1.148</version>
+      <version>3.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/DeleteData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/DeleteData.java
@@ -19,8 +19,12 @@
  */
 package com.xpn.xwiki.plugin.lucene;
 
-import com.google.common.base.Preconditions;
-import com.xpn.xwiki.XWikiContext;
+import static com.google.common.base.Preconditions.*;
+
+import org.apache.lucene.document.Document;
+
+import com.google.common.base.Strings;
+import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 public class DeleteData extends AbstractIndexData {
@@ -29,7 +33,7 @@ public class DeleteData extends AbstractIndexData {
 
   public DeleteData(String docId) {
     super("", null, true);
-    this.docId = Preconditions.checkNotNull(docId);
+    this.docId = checkNotNull(Strings.emptyToNull(docId));
   }
 
   @Override
@@ -38,8 +42,12 @@ public class DeleteData extends AbstractIndexData {
   }
 
   @Override
-  protected void getFullText(StringBuilder sb, XWikiDocument doc, XWikiContext context) {
-    // nothing to do
+  public void addDataToLuceneDocument(Document luceneDoc) throws XWikiException {
+  }
+
+  @Override
+  public String getFullText(XWikiDocument doc) {
+    return "";
   }
 
 }

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexRebuilder.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexRebuilder.java
@@ -367,7 +367,6 @@ public class IndexRebuilder extends AbstractXWikiRunnable {
   protected int queueDocument(DocumentMetaData metaData) throws InterruptedException {
     int retval = 0;
     try {
-
       XWikiDocument doc = getModelAccess().getDocument(metaData.getDocRef(),
           metaData.getLanguage());
       waitForLowQueueSize();
@@ -419,9 +418,9 @@ public class IndexRebuilder extends AbstractXWikiRunnable {
       IndexSearcher searcher) throws IOException {
     boolean exists = false;
     BooleanQuery query = getLuceneSearchRefQuery(docRef);
-    query.add(new TermQuery(new Term(IndexFields.DOCUMENT_LANGUAGE, Strings.isNullOrEmpty(language)
-        ? "default"
-        : language)), BooleanClause.Occur.MUST);
+    language = Strings.isNullOrEmpty(language) ? "default" : language;
+    query.add(new TermQuery(new Term(IndexFields.DOCUMENT_LANGUAGE, language)),
+        BooleanClause.Occur.MUST);
     if (version != null) {
       query.add(new TermQuery(new Term(IndexFields.DOCUMENT_VERSION, version.toString())),
           BooleanClause.Occur.MUST);

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/WikiData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/WikiData.java
@@ -19,10 +19,13 @@
  */
 package com.xpn.xwiki.plugin.lucene;
 
+import static com.google.common.base.Preconditions.*;
+
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
 import org.xwiki.model.reference.WikiReference;
 
-import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 /**
@@ -35,7 +38,12 @@ import com.xpn.xwiki.doc.XWikiDocument;
 public class WikiData extends AbstractIndexData {
 
   public WikiData(WikiReference wikiReference, boolean deleted) {
-    super(null, wikiReference, deleted);
+    super(null, checkNotNull(wikiReference), deleted);
+  }
+
+  @Override
+  public String getId() {
+    return getWiki();
   }
 
   @Override
@@ -44,13 +52,12 @@ public class WikiData extends AbstractIndexData {
   }
 
   @Override
-  protected void getFullText(StringBuilder sb, XWikiDocument doc, XWikiContext context) {
-    // nothing to do
+  public void addDataToLuceneDocument(Document luceneDoc) throws XWikiException {
   }
 
   @Override
-  public String getId() {
-    // TODO Auto-generated method stub
-    return null;
+  public String getFullText(XWikiDocument doc) {
+    return "";
   }
+
 }

--- a/src/test/java/com/xpn/xwiki/plugin/lucene/AttachmentDataTest.java
+++ b/src/test/java/com/xpn/xwiki/plugin/lucene/AttachmentDataTest.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.rendering.syntax.Syntax;
 
 import com.celements.common.test.AbstractBridgedComponentTestCase;
 import com.xpn.xwiki.XWikiException;
@@ -57,6 +58,7 @@ public class AttachmentDataTest extends AbstractBridgedComponentTestCase {
   public void setUp_AttachmentDataTest() throws Exception {
     DocumentReference docRef = new DocumentReference("wiki", "space", "page");
     this.document = new XWikiDocument(docRef);
+    this.document.setSyntax(Syntax.XWIKI_1_0);
     this.document.setTitle(docRef.getName());
     this.attachment = new XWikiAttachment(this.document, "filename");
     this.document.getAttachmentList().add(this.attachment);

--- a/src/test/java/com/xpn/xwiki/plugin/lucene/AttachmentDataTest.java
+++ b/src/test/java/com/xpn/xwiki/plugin/lucene/AttachmentDataTest.java
@@ -136,10 +136,9 @@ public class AttachmentDataTest extends AbstractBridgedComponentTestCase {
     attachment.setContent(getClass().getResourceAsStream("/" + filename));
     expect(servletContext.getMimeType(eq(filename))).andReturn(mimetype).once();
     replayDefault();
-    this.attachmentData = new AttachmentData(this.attachment, false, getContext());
+    this.attachmentData = new AttachmentData(this.attachment, false);
     this.attachmentData.setFilename(filename);
-    assertEquals("Wrong attachment content indexed", content, attachmentData.getFullText(document,
-        getContext()));
+    assertEquals("Wrong attachment content indexed", content, attachmentData.getFullText(document));
     assertEquals("Wrong mimetype content indexed", mimetype, attachmentData.getMimeType());
     verifyDefault();
   }

--- a/src/test/java/com/xpn/xwiki/plugin/lucene/indexExtension/LuceneIndexExtensionServiceTest.java
+++ b/src/test/java/com/xpn/xwiki/plugin/lucene/indexExtension/LuceneIndexExtensionServiceTest.java
@@ -1,5 +1,6 @@
 package com.xpn.xwiki.plugin.lucene.indexExtension;
 
+import static com.celements.common.test.CelementsTestUtils.*;
 import static junit.framework.Assert.*;
 
 import org.junit.Before;


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-659

- add `notifyObservationEvents`
- made `queue(AbstractIndexData)` public to be used from `IndexRebuilder`
- removed `XWikiContext` and duplicate javadoc from signatures
- removed unnecessary protected `getFullText`