### PR TITLE
CELDEV-782 Lucene DeleteData NPE

### DIFF
--- a/src/main/java/com/celements/search/lucene/LuceneDocType.java
+++ b/src/main/java/com/celements/search/lucene/LuceneDocType.java
@@ -1,0 +1,5 @@
+package com.celements.search.lucene;
+
+public enum LuceneDocType {
+  wikipage, attachment, none;
+}

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/AbstractDocumentData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/AbstractDocumentData.java
@@ -35,6 +35,7 @@ import org.xwiki.rendering.syntax.Syntax;
 
 import com.celements.model.access.IModelAccessFacade;
 import com.celements.model.access.exception.DocumentNotExistsException;
+import com.celements.search.lucene.LuceneDocType;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.web.Utils;
@@ -103,7 +104,7 @@ public abstract class AbstractDocumentData extends AbstractIndexData {
 
   private Date modificationDate;
 
-  public AbstractDocumentData(String type, XWikiDocument doc, boolean deleted) {
+  public AbstractDocumentData(LuceneDocType type, XWikiDocument doc, boolean deleted) {
     super(type, checkNotNull(doc).getDocumentReference(), deleted);
 
     setVersion(doc.getVersion());
@@ -152,7 +153,7 @@ public abstract class AbstractDocumentData extends AbstractIndexData {
     }
 
     if (getType() != null) {
-      addFieldToDocument(IndexFields.DOCUMENT_TYPE, getType(), Field.Store.YES,
+      addFieldToDocument(IndexFields.DOCUMENT_TYPE, getType().name(), Field.Store.YES,
           Field.Index.NOT_ANALYZED, TYPE_BOOST, luceneDoc);
     }
     if (this.modificationDate != null) {

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/AbstractIndexData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/AbstractIndexData.java
@@ -29,7 +29,7 @@ import org.xwiki.model.reference.EntityReferenceSerializer;
 
 import com.celements.model.context.ModelContext;
 import com.celements.model.util.ModelUtils;
-import com.google.common.base.Strings;
+import com.celements.search.lucene.LuceneDocType;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.web.Utils;
 
@@ -39,7 +39,7 @@ import com.xpn.xwiki.web.Utils;
  */
 public abstract class AbstractIndexData {
 
-  private String type;
+  private LuceneDocType type;
 
   private boolean deleted;
 
@@ -47,8 +47,8 @@ public abstract class AbstractIndexData {
 
   private boolean notifyObservationEvents = true;
 
-  public AbstractIndexData(String type, EntityReference entityReference, boolean deleted) {
-    this.type = checkNotNull(Strings.emptyToNull(type));
+  public AbstractIndexData(LuceneDocType type, EntityReference entityReference, boolean deleted) {
+    this.type = checkNotNull(type);
     setEntityReference(entityReference);
     setDeleted(deleted);
   }
@@ -92,7 +92,7 @@ public abstract class AbstractIndexData {
     return new Term(IndexFields.DOCUMENT_ID, getId());
   }
 
-  public String getType() {
+  public LuceneDocType getType() {
     return this.type;
   }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/AttachmentData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/AttachmentData.java
@@ -34,6 +34,7 @@ import org.apache.tika.metadata.TikaMetadataKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.celements.search.lucene.LuceneDocType;
 import com.google.common.base.Strings;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -85,7 +86,7 @@ public class AttachmentData extends AbstractDocumentData {
   private String mimetype;
 
   public AttachmentData(XWikiAttachment attachment, boolean deleted) {
-    super(LucenePlugin.DOCTYPE_ATTACHMENT, checkNotNull(attachment).getDoc(), deleted);
+    super(LuceneDocType.attachment, checkNotNull(attachment).getDoc(), deleted);
     setModificationDate(attachment.getDate());
     setAuthor(attachment.getAuthor());
     setSize(attachment.getFilesize());
@@ -94,7 +95,7 @@ public class AttachmentData extends AbstractDocumentData {
   }
 
   public AttachmentData(XWikiDocument document, String filename, boolean deleted) {
-    super(LucenePlugin.DOCTYPE_ATTACHMENT, document, deleted);
+    super(LuceneDocType.attachment, document, deleted);
     setFilename(filename);
   }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/DeleteData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/DeleteData.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.*;
 
 import org.apache.lucene.document.Document;
 
+import com.celements.search.lucene.LuceneDocType;
 import com.google.common.base.Strings;
 import com.xpn.xwiki.XWikiException;
 
@@ -31,7 +32,7 @@ public class DeleteData extends AbstractIndexData {
   private final String docId;
 
   public DeleteData(String docId) {
-    super("", null, true);
+    super(LuceneDocType.none, null, true);
     this.docId = checkNotNull(Strings.emptyToNull(docId));
   }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/DocumentData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/DocumentData.java
@@ -29,6 +29,7 @@ import org.apache.lucene.document.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.celements.search.lucene.LuceneDocType;
 import com.celements.web.plugin.cmd.ConvertToPlainTextException;
 import com.celements.web.plugin.cmd.PlainTextCommand;
 import com.xpn.xwiki.XWikiContext;
@@ -63,7 +64,7 @@ public class DocumentData extends AbstractDocumentData {
   private PlainTextCommand plainTextCmd = new PlainTextCommand();
 
   public DocumentData(XWikiDocument doc, boolean deleted) {
-    super(LucenePlugin.DOCTYPE_WIKIPAGE, doc, deleted);
+    super(LuceneDocType.wikipage, doc, deleted);
     setAuthor(doc.getAuthor());
     setCreator(doc.getCreator());
     setModificationDate(doc.getDate());

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexRebuilder.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexRebuilder.java
@@ -357,6 +357,8 @@ public class IndexRebuilder extends AbstractXWikiRunnable {
 
   private void cleanIndex(Set<String> danglingDocs) throws InterruptedException {
     LOGGER.info("cleanIndex: {} for {} dangling docs", !wipeIndex, danglingDocs.size());
+    danglingDocs.remove(null);
+    danglingDocs.remove("");
     for (String docId : danglingDocs) {
       waitForLowQueueSize();
       queue(new DeleteData(docId));

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/LucenePlugin.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/LucenePlugin.java
@@ -64,6 +64,7 @@ import org.xwiki.model.reference.WikiReference;
 import org.xwiki.observation.ObservationManager;
 
 import com.celements.model.util.References;
+import com.celements.search.lucene.LuceneDocType;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
@@ -96,9 +97,11 @@ public class LucenePlugin extends XWikiDefaultPlugin {
 
   public static final String SORT_FIELD_SCORE = "score";
 
-  public static final String DOCTYPE_WIKIPAGE = "wikipage";
+  @Deprecated
+  public static final String DOCTYPE_WIKIPAGE = LuceneDocType.wikipage.name();
 
-  public static final String DOCTYPE_ATTACHMENT = "attachment";
+  @Deprecated
+  public static final String DOCTYPE_ATTACHMENT = LuceneDocType.attachment.name();
 
   public static final String PROP_INDEX_DIR = "xwiki.plugins.lucene.indexdir";
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/WikiData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/WikiData.java
@@ -25,6 +25,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.Term;
 import org.xwiki.model.reference.WikiReference;
 
+import com.celements.search.lucene.LuceneDocType;
 import com.xpn.xwiki.XWikiException;
 
 /**
@@ -37,7 +38,7 @@ import com.xpn.xwiki.XWikiException;
 public class WikiData extends AbstractIndexData {
 
   public WikiData(WikiReference wikiReference, boolean deleted) {
-    super(null, checkNotNull(wikiReference), deleted);
+    super(LuceneDocType.none, checkNotNull(wikiReference), deleted);
   }
 
   @Override


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-782

Note: `new IndexData` and `type` is used internally in the `LucenePlugin` only, hence it's not part of the API. From outside the `LucenePlugin` is called.