### PR TITLE
CELDEV-828 xmlbeans included twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-      <version>1.21</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
       <version>1.21</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!-- IMPORTANT: includes transitive dependency 'poi-ooxml-4.0.1'
+        on tika upgrade match other existing versions accordingly -->
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
       <version>1.21</version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.3</version>
+      <version>1.21</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-parsers</artifactId>
-      <version>1.3</version>
+      <version>1.21</version>
     </dependency>
     <dependency>
       <groupId>asm</groupId>

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/AttachmentData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/AttachmentData.java
@@ -21,6 +21,8 @@ package com.xpn.xwiki.plugin.lucene;
 
 import static com.google.common.base.Preconditions.*;
 
+import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +32,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Fieldable;
 import org.apache.tika.Tika;
+import org.apache.tika.exception.TikaException;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaMetadataKeys;
 import org.slf4j.Logger;
@@ -37,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import com.celements.search.lucene.LuceneDocType;
 import com.google.common.base.Strings;
+import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 
@@ -184,13 +188,26 @@ public class AttachmentData extends AbstractDocumentData {
       Tika tika = new Tika();
       Metadata metadata = new Metadata();
       metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, this.filename);
-      try (InputStream is = att.getContentInputStream(getContext().getXWikiContext())) {
+      try (InputStream is = getContentInputStream(att)) {
         contentText = StringUtils.lowerCase(tika.parseToString(is, metadata));
       }
-    } catch (Throwable ex) {
+    } catch (XWikiException | IOException | TikaException ex) {
       LOGGER.error("error getting content of attachment [{}] for document [{}]", this.filename,
           doc.getDocumentReference(), ex);
     }
     return contentText;
+  }
+
+  /**
+   * We wrap the content input stream in a BufferedInputStream to make sure that all the detectors can
+   * read the content even if the input stream is configured to auto close when it reaches the end.
+   * This can happen for small files if AutoCloseInputStream is used, which supports the mark and reset
+   * methods so Tika uses it directly. In this case, the input stream is automatically closed after the
+   * first detector reads it so the next detector fails to read it.
+   * @see https://issues.apache.org/jira/browse/TIKA-2395
+   * @see https://issues.apache.org/jira/browse/IO-568
+   */
+  private BufferedInputStream getContentInputStream(XWikiAttachment att) throws XWikiException {
+    return new BufferedInputStream(att.getContentInputStream(getContext().getXWikiContext()));
   }
 }

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/AttachmentData.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/AttachmentData.java
@@ -21,6 +21,7 @@ package com.xpn.xwiki.plugin.lucene;
 
 import static com.google.common.base.Preconditions.*;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -176,25 +177,20 @@ public class AttachmentData extends AbstractDocumentData {
 
   private String getContentAsText(XWikiDocument doc) {
     String contentText = null;
-
     try {
       XWikiAttachment att = doc.getAttachment(this.filename);
-
       LOGGER.debug("Start parsing attachement [{}] in document [{}]", this.filename,
           doc.getDocumentReference());
-
       Tika tika = new Tika();
-
       Metadata metadata = new Metadata();
       metadata.set(TikaMetadataKeys.RESOURCE_NAME_KEY, this.filename);
-
-      contentText = StringUtils.lowerCase(tika.parseToString(att.getContentInputStream(
-          getContext().getXWikiContext()), metadata));
+      try (InputStream is = att.getContentInputStream(getContext().getXWikiContext())) {
+        contentText = StringUtils.lowerCase(tika.parseToString(is, metadata));
+      }
     } catch (Throwable ex) {
       LOGGER.error("error getting content of attachment [{}] for document [{}]", this.filename,
           doc.getDocumentReference(), ex);
     }
-
     return contentText;
   }
 }

--- a/src/test/java/com/xpn/xwiki/plugin/lucene/AttachmentDataTest.java
+++ b/src/test/java/com/xpn/xwiki/plugin/lucene/AttachmentDataTest.java
@@ -19,6 +19,7 @@
  */
 package com.xpn.xwiki.plugin.lucene;
 
+import static com.celements.common.test.CelementsTestUtils.*;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
@@ -32,7 +33,7 @@ import org.junit.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.syntax.Syntax;
 
-import com.celements.common.test.AbstractBridgedComponentTestCase;
+import com.celements.common.test.AbstractComponentTest;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -44,7 +45,7 @@ import com.xpn.xwiki.web.XWikiServletContext;
  *
  * @version $Id: 6235ccd3b45c79ed04c8c9ef57f99a45e11fbc01 $
  */
-public class AttachmentDataTest extends AbstractBridgedComponentTestCase {
+public class AttachmentDataTest extends AbstractComponentTest {
 
   private XWikiDocument document;
 
@@ -139,10 +140,9 @@ public class AttachmentDataTest extends AbstractBridgedComponentTestCase {
     expect(servletContext.getMimeType(eq(filename))).andReturn(mimetype).once();
     replayDefault();
     this.attachmentData = new AttachmentData(this.attachment, false);
-    this.attachmentData.setFilename(filename);
+    verifyDefault();
     assertEquals("Wrong attachment content indexed", content, attachmentData.getFullText(document));
     assertEquals("Wrong mimetype content indexed", mimetype, attachmentData.getMimeType());
-    verifyDefault();
   }
 
 }


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-828

- **tika**: 1.3 -> 1.21
- workaround for `AutoCloseInputStream` bug