### PR TITLE
SearchProvider Memory Leak fix

### DIFF
--- a/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/IndexUpdater.java
@@ -297,7 +297,7 @@ public class IndexUpdater extends AbstractXWikiRunnable implements EventListener
   public void commitIndex() throws IOException {
     LOGGER.debug("commitIndex");
     writer.commit();
-    plugin.openSearchers();
+    plugin.closeSearcherProvider();
   }
 
   public void queueDeletion(String docId) {

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.slf4j.Logger;
@@ -122,14 +121,8 @@ public class SearcherProvider implements AutoCloseable {
    */
   synchronized void tryClose() throws IOException {
     removeOrphanedThreads();
-    if (isMarkedToClose()) {
-      if (isIdle()) {
-        closeSearchers();
-      } else {
-        Stream.concat(connectedThreads.stream(), connectedSearchResults.keySet().stream())
-            .distinct().forEach(thread -> LOGGER.info("thread [{}] still connected in state [{}]",
-                thread, thread.getState()));
-      }
+    if (isMarkedToClose() && isIdle()) {
+      closeSearchers();
     }
   }
 

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProvider.java
@@ -54,7 +54,7 @@ public class SearcherProvider implements AutoCloseable {
 
   final ConcurrentMap<Thread, Set<SearchResults>> connectedSearchResults = new ConcurrentHashMap<>();
 
-  private AtomicBoolean markToClose = new AtomicBoolean(false);
+  private final AtomicBoolean markToClose = new AtomicBoolean(false);
 
   SearcherProvider(List<IndexSearcher> searchers, DisconnectToken token) {
     this.backedSearchers = searchers;

--- a/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProviderManager.java
+++ b/src/main/java/com/xpn/xwiki/plugin/lucene/searcherProvider/SearcherProviderManager.java
@@ -22,6 +22,7 @@ package com.xpn.xwiki.plugin.lucene.searcherProvider;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -98,8 +99,24 @@ public class SearcherProviderManager implements ISearcherProviderRole {
     } else if (getAllSearcherProviders().size() > 10) {
       LOGGER.info("createSearchProvider in manager [{}]: list increased to size [{}].",
           System.identityHashCode(this), getAllSearcherProviders().size());
+    } else if (getAllSearcherProviders().size() > 5) {
+      LOGGER.debug("createSearchProvider in manager [{}]: list increased to size [{}],"
+          + " number of connected Threads is [{}].", System.identityHashCode(this),
+          getAllSearcherProviders().size(), getConnectedThreads(getAllSearcherProviders()).size());
+    } else if (getAllSearcherProviders().size() > 3) {
+      LOGGER.trace("createSearchProvider in manager [{}]: list increased to size [{}],"
+          + " connected Threads are [{}].", System.identityHashCode(this),
+          getAllSearcherProviders().size(), getConnectedThreads(getAllSearcherProviders()));
     }
     return newSearcherProvider;
+  }
+
+  private Set<Thread> getConnectedThreads(Set<SearcherProvider> allSearcherProviders) {
+    Set<Thread> connectedThreads = new HashSet<>();
+    for (SearcherProvider searchProvider : allSearcherProviders) {
+      connectedThreads.addAll(searchProvider.internal_getConnectedThreads());
+    }
+    return connectedThreads;
   }
 
   class DisconnectToken {


### PR DESCRIPTION
- SearchProvider orphaned thread check fixed for thread pools 
- use SearchProvider in try-with-resource to avoid misuse

https://synjira.atlassian.net/browse/CELDEV-805